### PR TITLE
feat: add analytic and speed insight from vercel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "@sentry/nextjs": "^8.43.0",
         "@spotlightjs/spotlight": "^2.7.0",
         "@t3-oss/env-nextjs": "^0.11.1",
+        "@vercel/analytics": "^1.4.1",
+        "@vercel/speed-insights": "^1.1.0",
         "next": "^15.1.0",
         "next-intl": "^3.26.0",
         "pg": "^8.13.1",
@@ -11157,6 +11159,77 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.4.1.tgz",
+      "integrity": "sha512-ekpL4ReX2TH3LnrRZTUKjHHNpNy9S1I7QmS+g/RQXoSUQ8ienzosuX7T9djZ/s8zPhBx1mpHP/Rw5875N+zQIQ==",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.1.0.tgz",
+      "integrity": "sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg==",
+      "hasInstallScript": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "@sentry/nextjs": "^8.43.0",
     "@spotlightjs/spotlight": "^2.7.0",
     "@t3-oss/env-nextjs": "^0.11.1",
+    "@vercel/analytics": "^1.4.1",
+    "@vercel/speed-insights": "^1.1.0",
     "next": "^15.1.0",
     "next-intl": "^3.26.0",
     "pg": "^8.13.1",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import arcjet, { detectBot, request } from '@/libs/Arcjet';
 import { Env } from '@/libs/Env';
 import { routing } from '@/libs/i18nNavigation';
+import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
@@ -93,6 +95,8 @@ export default async function RootLayout(props: {
         >
           {props.children}
         </NextIntlClientProvider>
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
This pull request includes the integration of Vercel's analytics and speed insights into the project. The most important changes are as follows:

### Dependency Updates:
* Added `@vercel/analytics` version `^1.4.1` and `@vercel/speed-insights` version `^1.1.0` to the `package.json` file.

### Code Integration:
* Imported `Analytics` and `SpeedInsights` from Vercel in `src/app/[locale]/layout.tsx`. ([src/app/[locale]/layout.tsxR5-R6](diffhunk://#diff-d387de9ed27220b8f151f3debc731746f2804b3e509aa2f99de6d40137df203aR5-R6))
* Added `<Analytics />` and `<SpeedInsights />` components to the `RootLayout` function in `src/app/[locale]/layout.tsx` to enable their functionalities. ([src/app/[locale]/layout.tsxR98-R99](diffhunk://#diff-d387de9ed27220b8f151f3debc731746f2804b3e509aa2f99de6d40137df203aR98-R99))